### PR TITLE
2-mod-fix-patch-136F

### DIFF
--- a/PathfindingCustomizer/Mod.cs
+++ b/PathfindingCustomizer/Mod.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿ using System;
 using System.Collections.Generic;
 using Colossal.Logging;
 using Game;

--- a/PathfindingCustomizer/Properties/PublishConfiguration.xml
+++ b/PathfindingCustomizer/Properties/PublishConfiguration.xml
@@ -36,16 +36,16 @@ With **Pathfinding Customizer**, you can:
 	<!--Link to the forum post where the mod can be discussed-->
 	<ForumLink Value="https://forum.paradoxplaza.com/forum/threads/pathfinding-customizer.1697643/" />
 	<!--Version of the mod-->
-	<ModVersion Value="1.0.9" />
+	<ModVersion Value="1.0.10" />
 	<!--Recommended version of the base game to use the mod-->
-	<GameVersion Value="1.1.*" />
+	<GameVersion Value="1.3.*" />
 	<!--Dependency for the mod, can be set multiple times-->
 <!--	<Dependency Id="" />-->
 	<!--Change log for new version. Single line or multi line. Supports minimal markdown subset-->
 <!--	<ChangeLog Value="-->
 	<ChangeLog>
 		
-- **updated** The max procentage to 1000% for all settings to allow more flexibility for larger cities. (Note: This may cause issues with population growth, lower the settings if you experience this issue)
+- **Fixed** Incompatible with the latest version of the game
 		
 	</ChangeLog>
 	<!--External link. supported types are discord, github, youtube, twitch, x, paypal, patreon, buymeacoffee, kofi, crowdin, gitlab-->

--- a/PathfindingCustomizer/Properties/PublishProfiles/PublishNewMod.pubxml
+++ b/PathfindingCustomizer/Properties/PublishProfiles/PublishNewMod.pubxml
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
-	<PropertyGroup>
-		<Configuration>Release</Configuration>
-		<Platform>Any CPU</Platform>
-		<PublishProtocol>FileSystem</PublishProtocol>
-		<_TargetId>Folder</_TargetId>
-		<TargetFramework>net472</TargetFramework>
-		<PublishDir>bin\$(Configuration)\$(TargetFramework)\</PublishDir>
-		<ModPublisherCommand>Publish</ModPublisherCommand>
-	</PropertyGroup>
+    <PropertyGroup>
+        <Configuration>Release</Configuration>
+        <Platform>Any CPU</Platform>
+        <PublishProtocol>FileSystem</PublishProtocol>
+        <_TargetId>Folder</_TargetId>
+        <TargetFramework>net48</TargetFramework>
+        <PublishDir>bin\$(Configuration)\$(TargetFramework)\</PublishDir>
+        <ModPublisherCommand>Publish</ModPublisherCommand>
+    </PropertyGroup>
 </Project>

--- a/PathfindingCustomizer/Properties/PublishProfiles/PublishNewVersion.pubxml
+++ b/PathfindingCustomizer/Properties/PublishProfiles/PublishNewVersion.pubxml
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
-	<PropertyGroup>
-		<Configuration>Release</Configuration>
-		<Platform>Any CPU</Platform>
-		<PublishProtocol>FileSystem</PublishProtocol>
-		<_TargetId>Folder</_TargetId>
-		<TargetFramework>net472</TargetFramework>
-		<PublishDir>bin\$(Configuration)\$(TargetFramework)\</PublishDir>
-		<ModPublisherCommand>NewVersion</ModPublisherCommand>
-	</PropertyGroup>
+    <PropertyGroup>
+        <Configuration>Release</Configuration>
+        <Platform>Any CPU</Platform>
+        <PublishProtocol>FileSystem</PublishProtocol>
+        <_TargetId>Folder</_TargetId>
+        <TargetFramework>net48</TargetFramework>
+        <PublishDir>bin\$(Configuration)\$(TargetFramework)\</PublishDir>
+        <ModPublisherCommand>NewVersion</ModPublisherCommand>
+    </PropertyGroup>
 </Project>

--- a/PathfindingCustomizer/Properties/PublishProfiles/UpdatePublishedConfiguration.pubxml
+++ b/PathfindingCustomizer/Properties/PublishProfiles/UpdatePublishedConfiguration.pubxml
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
-	<PropertyGroup>
-		<Configuration>Release</Configuration>
-		<Platform>Any CPU</Platform>
-		<PublishProtocol>FileSystem</PublishProtocol>
-		<_TargetId>Folder</_TargetId>
-		<TargetFramework>net472</TargetFramework>
-		<PublishDir>bin\$(Configuration)\$(TargetFramework)\</PublishDir>
-		<ModPublisherCommand>Update</ModPublisherCommand>
-	</PropertyGroup>
+    <PropertyGroup>
+        <Configuration>Release</Configuration>
+        <Platform>Any CPU</Platform>
+        <PublishProtocol>FileSystem</PublishProtocol>
+        <_TargetId>Folder</_TargetId>
+        <TargetFramework>net48</TargetFramework>
+        <PublishDir>bin\$(Configuration)\$(TargetFramework)\</PublishDir>
+        <ModPublisherCommand>Update</ModPublisherCommand>
+    </PropertyGroup>
 </Project>


### PR DESCRIPTION
This pull request updates the Pathfinding Customizer mod to ensure compatibility with the latest version of the game and modernizes the build configuration. The most important changes include updating the mod and game version metadata, fixing compatibility issues, and upgrading the target .NET framework in all publish profiles.

**Mod compatibility and metadata updates:**

* Updated the mod version to `1.0.10` and set the recommended game version to `1.3.*` to reflect support for the latest game release.
* Added a changelog entry noting that incompatibility with the latest game version has been fixed.

**Build configuration improvements:**

* Changed the target framework from `net472` to `net48` in all publish profile files (`PublishNewMod.pubxml`, `PublishNewVersion.pubxml`, and `UpdatePublishedConfiguration.pubxml`) to modernize the build configuration and ensure better compatibility. [[1]](diffhunk://#diff-f3744c2e3ab05ba9528fe738b52c82bf6b8812ae5bf90486dfeb95472d1d702fL8-R8) [[2]](diffhunk://#diff-9ed51f3976dfe18d9c7eabdb6e46131bf59c95e28e8aed49e52bee7bbfa5f917L8-R8) [[3]](diffhunk://#diff-4e41e2cdde0566db314106b1630b4db6202939d184881f979d8a6bddf3736678L8-R8)